### PR TITLE
Fix sed command for patching hardcoded path

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,6 @@ cmake \
 ninja install
 
 # https://github.com/google/benchmark/issues/824
-if [[ `uname -s` == "Linux*" ]]; then
-    sed -i -e 's:/usr/lib/x86_64-linux-gnu/librt.so:-lrt:g' ${PREFIX}/lib/cmake/benchmark/benchmarkTargets.cmake
+if [[ `uname -s` == "Linux" ]]; then
+    sed -i 's:INTERFACE_LINK_LIBRARIES "-pthread;.*:INTERFACE_LINK_LIBRARIES "-pthread;-lrt":g' ${PREFIX}/lib/cmake/benchmark/benchmarkTargets.cmake
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "benchmark" %}
-{% set version = "1.5" %}
+{% set version = "1.5.0" %}
 
 package:
   name: {{ name }}
@@ -8,10 +8,10 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/google/benchmark/archive/v{{ version }}.tar.gz
-  sha256: feba1c44cbace01627435a675aa271f4b012068dbea9922443c58fedd56eb5eb
+  sha256: 3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
Meanwhile google/benchmarks rereleased as `1.5.0` instead of `1.5`.

@pitrou I checked that this work but please also have a look at it.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
